### PR TITLE
Update run-server.md to note a prerequisite for setting up the config file

### DIFF
--- a/docs/run-server.md
+++ b/docs/run-server.md
@@ -14,7 +14,8 @@ Want to run your own Retag server? This is the documentation file for you!
     - `node` and `npm` can usually be installed from your distro's package manager.
 1. Install `wasm-pack` with `cargo install wasm-pack`
 1. From the `web` folder, run `yarn`
+1. In the `serv2` directory, run `yarn`.
 1. [Setup the config file](/docs/config.md).
 1. In `web`, run `yarn build` (or `yarn start` in dev)
 1. Publish `/web/dist` as a static site
-1. In the `serv2` directory, run `yarn`, then `./run.sh` to start the server (or `./watch.sh` in dev). This will start a server listening on the specified port that will serve the backend.
+1. In the `serv2` directory, run `./run.sh` to start the server (or `./watch.sh` in dev). This will start a server listening on the specified port that will serve the backend.


### PR DESCRIPTION
The config setup instructions request that the user runs
`node serv2/genVapidKeys.js`, but this requires dependencies in the `serv2`
directory.